### PR TITLE
Carpet: Add timing::total_threads variable

### DIFF
--- a/Carpet/interface.ccl
+++ b/Carpet/interface.ccl
@@ -450,6 +450,7 @@ CCTK_REAL timing TAGS='checkpoint="no"'
   comm_bytes_count
   
   time_levels
+  total_threads
 } "Physical timing information"
 
 CCTK_REAL timing_procs TYPE=array DIM=1 SIZE=1 DISTRIB=constant TAGS='checkpoint="no"'

--- a/Carpet/src/Timing.cc
+++ b/Carpet/src/Timing.cc
@@ -181,6 +181,8 @@ void InitTimingStats(cGH const *const cctkGH) {
     time_level[rl] = 0.0;
     time_level_count[rl] = 0.0;
   }
+
+  *total_threads = dist::total_num_threads();
 }
 
 // Begin timing (to be called after initialisation, just before the


### PR DESCRIPTION
@ianhinder's pull request 20 from https://bitbucket.org/eschnett/carpet/pull-requests/20

I would like to be able to analyse output data and determine things like computational cost, and number of cores used as a function of time. This branch has a prototype which satisfies my immediate needs, but might not be the best approach.

* It would also be nice to have directly the computational cost, which would probably be time_total * total_threads. This would be the cost for the current Cactus segment.
* Maybe we want cores rather than threads
* Maybe we want total cores available on the node rather than threads, since this is what is “spent”, even if it is not being used.

Thoughts?