### PR TITLE
make compatibility code compile once more

### DIFF
--- a/CarpetLib/src/bboxset1.hh
+++ b/CarpetLib/src/bboxset1.hh
@@ -190,10 +190,23 @@ public:
     return expand(lohi[0], lohi[1], denom);
   }
 
+  /** Expand the set (convolute with a bbox) */
+  bboxset expand(const T &lo, const T &hi) const {
+    return expand(vect<T, D>(lo), vect<T, D>(hi));
+  }
+
+  /** Expand the set (convolute with a bbox) */
+  bboxset expand(const T &lohi) const { return expand(lohi, lohi); }
+
   /** Shift the bboxset by multiples of a fraction of the stride.  */
   // cost: O(n)
   bboxset shift(const vect<T, D> &v, const vect<T, D> &denom) const {
     return expand(-v, v, denom);
+  }
+
+  /** Shift all points */
+  bboxset shift(const vect<T, D> &dist, const T &dist_denom) const {
+    return shift(dist, vect<T, D>(dist_denom));
   }
 
   /** Find the smallest b-compatible box around this bbox.

--- a/CarpetLib/src/bboxset2.hh
+++ b/CarpetLib/src/bboxset2.hh
@@ -219,7 +219,7 @@ template <typename T, int D> class bboxset {
           iter0 != end0 ? iter0->first : numeric_limits<T>::max();             \
       const T next_pos1 =                                                      \
           iter1 != end1 ? iter1->first : numeric_limits<T>::max();             \
-      const T pos = min(next_pos0, next_pos1);                                 \
+      const T pos = std::min(next_pos0, next_pos1);                            \
       const bool active0 = next_pos0 == pos;                                   \
       const bool active1 = next_pos1 == pos;                                   \
       const bboxset1 *const subset0p = active0 ? iter0->second.get() : 0;      \


### PR DESCRIPTION
* CarpetLib: add std namespace to CARPET_AVOID_LAMBDA code
* CarpetLib: provide shift and expand by int wrappers for bboxset1