### PR TITLE
vectorize CarpetInterp2's fasterp interpolation

### DIFF
--- a/CarpetInterp2/configuration.ccl
+++ b/CarpetInterp2/configuration.ccl
@@ -1,3 +1,3 @@
 # Configuration definitions for thorn CarpetInterp2
 
-REQUIRES Carpet CarpetLib
+REQUIRES Carpet CarpetLib Vectors

--- a/CarpetInterp2/interface.ccl
+++ b/CarpetInterp2/interface.ccl
@@ -16,6 +16,7 @@ USES INCLUDE HEADER: vect.hh
 USES INCLUDE HEADER: carpet.hh
 uses include header: Timer.hh
 
+uses include header: vectors.h
 
 
 # Get access to communicators


### PR DESCRIPTION
@rhaas80 's pull request 33 https://bitbucket.org/eschnett/carpet/pull-requests/33

* CarpetInterp2: use thorn Vectors for vectorization
* CarpetInterp2: remove buffer array