### PR TITLE
cache file handles in HDF5 output to avoid opening and closing the same file multiple times

### DIFF
--- a/CarpetIOHDF5/param.ccl
+++ b/CarpetIOHDF5/param.ccl
@@ -422,12 +422,20 @@ BOOLEAN out3D_outer_ghosts "Output outer boundary zones (assuming that there are
 {
 } "yes"
 
-# These parameters are here for historic reasons only.
-# They might go away in the future.  Do not use them.
+# This parameter is here for historic reasons only.
+# It might go away in the future.  Do not use it.
 
 BOOLEAN out1D_d "Do output along the diagonal" STEERABLE = ALWAYS
 {
 } "yes"
+
+KEYWORD flush_to_disk "How frequently to flush outND_vars data to disk" STEERABLE = ALWAYS
+{
+  "immediately" :: "flush as soon as the write finishes"
+  "reflevel" :: "after each refinement level output"
+  "iteration" :: "once per iteration"
+  "checkpoint" :: "before each checkpoint"
+} "immediately"
 
 #######################################################################
 # checkpoint/recovery

--- a/CarpetIOHDF5/schedule.ccl
+++ b/CarpetIOHDF5/schedule.ccl
@@ -46,6 +46,12 @@ schedule CarpetIOHDF5_CloseFiles at POSTINITIAL
   OPTIONS: global
 } "Close all filereader input files"
 
+schedule CarpetIOHDF5_CloseOutputFiles at PRESTEP
+{
+  LANG: C
+  OPTIONS: global
+} "Close all output files opened during last output"
+
 if (! CCTK_Equals (recover, "no") && *recover_file)
 {
   schedule CarpetIOHDF5_RecoverParameters at RECOVER_PARAMETERS

--- a/CarpetIOHDF5/src/CarpetIOHDF5.cc
+++ b/CarpetIOHDF5/src/CarpetIOHDF5.cc
@@ -107,8 +107,9 @@ void CarpetIOHDF5_InitialDataCheckpoint(CCTK_ARGUMENTS) {
   if (checkpoint and checkpoint_ID) {
     if (not CCTK_Equals(verbose, "none")) {
       CCTK_INFO("---------------------------------------------------------");
-      CCTK_VInfo(CCTK_THORNSTRING, "Dumping initial checkpoint at "
-                                   "iteration %d, simulation time %g",
+      CCTK_VInfo(CCTK_THORNSTRING,
+                 "Dumping initial checkpoint at "
+                 "iteration %d, simulation time %g",
                  cctk_iteration, double(cctk_time));
       CCTK_INFO("---------------------------------------------------------");
     }
@@ -146,8 +147,9 @@ void CarpetIOHDF5_EvolutionCheckpoint(CCTK_ARGUMENTS) {
   if (do_checkpoint) {
     if (not CCTK_Equals(verbose, "none")) {
       CCTK_INFO("---------------------------------------------------------");
-      CCTK_VInfo(CCTK_THORNSTRING, "Dumping periodic checkpoint at "
-                                   "iteration %d, simulation time %g",
+      CCTK_VInfo(CCTK_THORNSTRING,
+                 "Dumping periodic checkpoint at "
+                 "iteration %d, simulation time %g",
                  cctk_iteration, double(cctk_time));
       CCTK_INFO("---------------------------------------------------------");
     }
@@ -166,8 +168,9 @@ void CarpetIOHDF5_TerminationCheckpoint(CCTK_ARGUMENTS) {
         (cctk_iteration == 0 and not checkpoint_ID)) {
       if (not CCTK_Equals(verbose, "none")) {
         CCTK_INFO("---------------------------------------------------------");
-        CCTK_VInfo(CCTK_THORNSTRING, "Dumping termination checkpoint at "
-                                     "iteration %d, simulation time %g",
+        CCTK_VInfo(CCTK_THORNSTRING,
+                   "Dumping termination checkpoint at "
+                   "iteration %d, simulation time %g",
                    cctk_iteration, double(cctk_time));
         CCTK_INFO("---------------------------------------------------------");
       }
@@ -290,7 +293,7 @@ hid_t CCTKtoHDF5_Datatype(const cGH *const cctkGH, int cctk_type,
   case CCTK_VARIABLE_INT8:
     retval = H5T_NATIVE_INT64;
     break;
-  // case CCTK_VARIABLE_INT16:     retval = H5T_NATIVE_INT128; break;
+    // case CCTK_VARIABLE_INT16:     retval = H5T_NATIVE_INT128; break;
 
   case CCTK_VARIABLE_REAL4:
     retval = H5T_NATIVE_FLOAT;

--- a/CarpetIOHDF5/src/CarpetIOHDF5.cc
+++ b/CarpetIOHDF5/src/CarpetIOHDF5.cc
@@ -48,7 +48,7 @@ static int TimeToOutput(const cGH *const cctkGH, const int vindex);
 static int TriggerOutput(const cGH *const cctkGH, const int vindex);
 
 // general checkpoint routine
-static void Checkpoint(const cGH *const cctkGH, int called_from);
+static void Checkpoint(cGH *const cctkGH, int called_from);
 
 // callback for I/O parameter parsing routine
 static void GetVarIndex(int vindex, const char *optstring, void *arg);
@@ -1085,9 +1085,12 @@ static int OutputVarAs(const cGH *const cctkGH, const char *const fullname,
   return (0);
 }
 
-static void Checkpoint(const cGH *const cctkGH, int called_from) {
+static void Checkpoint(cGH *const cctkGH, int called_from) {
   int error_count = 0;
   DECLARE_CCTK_PARAMETERS;
+
+  if (CCTK_EQUALS(flush_to_disk, "checkpoint"))
+    CarpetIOHDF5_CloseOutputFiles(CCTK_PASS_CTOC);
 
   /* get the filenames for both the temporary and real checkpoint file */
   int ioproc = 0, nioprocs = 1;

--- a/CarpetIOHDF5/src/CarpetIOHDF5.hh
+++ b/CarpetIOHDF5/src/CarpetIOHDF5.hh
@@ -5,7 +5,7 @@
 #include <hdf5.h>
 
 #include <vector>
-#include <map>
+#include <unordered_set>
 
 #include "CactusBase/IOUtil/src/ioutil_Utils.h"
 #include "carpet.hh"
@@ -176,8 +176,20 @@ template <int outdim> struct IOHDF5 {
     hid_t index_file;
 
     hdf5_file_t() : filename(""), file(-1), index_file(-1){};
+    hdf5_file_t(const std::string &filename_) : filename(filename), file(-1), index_file(-1){};
+
+    struct hash {
+      size_t operator()(const hdf5_file_t &a) const {
+        return std::hash<std::string>()(a.filename);
+      };
+    };
+    struct equals {
+      bool operator()(const hdf5_file_t &a, const hdf5_file_t &b) const {
+        return a.filename == b.filename;
+      };
+    };
   };
-  typedef std::map<std::string, hdf5_file_t> hdf5_files_t;
+  typedef std::unordered_set<hdf5_file_t, typename hdf5_file_t::hash, typename hdf5_file_t::equals> hdf5_files_t;
   static hdf5_files_t hdf5_files;
 
   // Scheduled functions
@@ -221,7 +233,7 @@ template <int outdim> struct IOHDF5 {
                        const vect<CCTK_REAL, dim> &coord_upper,
                        const vect<CCTK_REAL, dim> &coord_delta);
 
-  static int CloseFile(const cGH *cctkGH, hdf5_file_t &file);
+  static int CloseFile(const cGH *cctkGH, const hdf5_file_t &file);
 
   static int CloseFiles(const cGH *const cctkGH);
 

--- a/CarpetIOHDF5/src/Input.cc
+++ b/CarpetIOHDF5/src/Input.cc
@@ -274,8 +274,9 @@ int CarpetIOHDF5_SetNumRefinementLevels() {
       char *buffer =
           CCTK_ParameterValString("refinement_levels", "CarpetRegrid");
       assert(buffer);
-      CCTK_VInfo(CCTK_THORNSTRING, "Using %i reflevels from checkpoint file. "
-                                   "Ignoring value '%s' in parameter file.",
+      CCTK_VInfo(CCTK_THORNSTRING,
+                 "Using %i reflevels from checkpoint file. "
+                 "Ignoring value '%s' in parameter file.",
                  num_reflevels, buffer);
       free(buffer);
     }
@@ -858,10 +859,11 @@ int Recover(cGH *cctkGH, const char *basefilename, int called_from) {
   }
 
   if (in_recovery and not CCTK_Equals(verbose, "none")) {
-    CCTK_VInfo(
-        CCTK_THORNSTRING, "restarting simulation on mglevel %d reflevel %d "
-                          "at iteration %d (simulation time %g)",
-        mglevel, reflevel, cctkGH->cctk_iteration, (double)cctkGH->cctk_time);
+    CCTK_VInfo(CCTK_THORNSTRING,
+               "restarting simulation on mglevel %d reflevel %d "
+               "at iteration %d (simulation time %g)",
+               mglevel, reflevel, cctkGH->cctk_iteration,
+               (double)cctkGH->cctk_time);
   }
 
   return (0);
@@ -982,8 +984,9 @@ static list<fileset_t>::iterator OpenFileSet(const cGH *const cctkGH,
   // recover parameters
   if (called_from == CP_RECOVER_PARAMETERS) {
     if (not CCTK_Equals(verbose, "none")) {
-      CCTK_VInfo(CCTK_THORNSTRING, "Recovering parameters from checkpoint "
-                                   "file '%s'",
+      CCTK_VInfo(CCTK_THORNSTRING,
+                 "Recovering parameters from checkpoint "
+                 "file '%s'",
                  file.filename);
     }
     hid_t dataset, datatype, memtype = -1;
@@ -1411,7 +1414,7 @@ static int ReadVar(const cGH *const cctkGH, file_t &file, CCTK_REAL &io_bytes,
         upper[dir] = newupper;
       }
       const ibbox filebox(lower, upper, stride);
-// cout << "Found in file: " << filebox << endl;
+      // cout << "Found in file: " << filebox << endl;
 
 #if 0
       const ibbox& interior_membox =

--- a/CarpetIOHDF5/src/Output.cc
+++ b/CarpetIOHDF5/src/Output.cc
@@ -208,9 +208,9 @@ int WriteVarUnchunked(const cGH *const cctkGH, hid_t outfile,
         if (local_component != -1) {
           ostringstream buf;
           buf << (dd->local_boxes.at(mglevel)
-                    .at(refinementlevel)
-                    .at(local_component)
-                    .active);
+                      .at(refinementlevel)
+                      .at(local_component)
+                      .active);
           active = buf.str();
         }
         if (local_component == -1 or dist::rank() != 0) {
@@ -410,9 +410,9 @@ int WriteVarChunkedSequential(const cGH *const cctkGH, hid_t outfile,
       if (local_component != -1) {
         ostringstream buf;
         buf << (dd->local_boxes.at(mglevel)
-                  .at(refinementlevel)
-                  .at(local_component)
-                  .active);
+                    .at(refinementlevel)
+                    .at(local_component)
+                    .active);
         active = buf.str();
       }
       if (local_component == -1 or dist::rank() != 0) {
@@ -620,13 +620,12 @@ int WriteVarChunkedParallel(const cGH *const cctkGH, hid_t outfile,
       {
         ostringstream buf;
         buf << (dd->local_boxes.at(mglevel)
-                  .at(refinementlevel)
-                  .at(local_component)
-                  .active);
+                    .at(refinementlevel)
+                    .at(local_component)
+                    .active);
 
         active = buf.str();
       }
-
 
       // As per Cactus convention, DISTRIB=CONSTANT arrays
       // (including grid scalars) are assumed to be the same on

--- a/CarpetIOHDF5/src/OutputSlice.cc
+++ b/CarpetIOHDF5/src/OutputSlice.cc
@@ -676,12 +676,11 @@ void IOHDF5<outdim>::OutputDirection(const cGH *const cctkGH, const int vindex,
               }
               const ibbox outext(lo, hi, ext.stride());
               if (outext.intersects(ext)) {
-                error_count +=
-                    WriteHDF5(cctkGH, file, index_file, tmpdatas, ext, vindex,
-                              offsets1[c_offset], dirs, rl, ml, m, c,
-                              c_base + c_offset, tl, coord_time,
-                              coord_lower[c_offset], coord_upper[c_offset],
-                              coord_delta[c_offset]);
+                error_count += WriteHDF5(
+                    cctkGH, file, index_file, tmpdatas, ext, vindex,
+                    offsets1[c_offset], dirs, rl, ml, m, c, c_base + c_offset,
+                    tl, coord_time, coord_lower[c_offset],
+                    coord_upper[c_offset], coord_delta[c_offset]);
               }
               ++c_offset;
             }
@@ -1133,7 +1132,7 @@ void GetCoordinates(const cGH *const cctkGH, const int m,
       global_lower[d] = cctk_origin_space[d];
       // grid spacing of Carpet's integer indexing
       global_delta[d] = (cctk_delta_space[d] /
-                        vhh.at(m)->baseextents.at(0).at(0).stride()[d]);
+                         vhh.at(m)->baseextents.at(0).at(0).stride()[d]);
     }
   } else {
     for (int d = 0; d < dim; ++d) {


### PR DESCRIPTION
@rhaas80's pull request 34 https://bitbucket.org/eschnett/carpet/pull-requests/34

* CarpetIOHDF5: keep outND_var files open until all data is written

    this reduces file system open/close calls from once per variable per reflevel per iteration of output to once per variable per iteration of output or less (if one_file_per_group or one_file_per_proc is used).

    It does however keep more files open which can be an issue if the OS limit on open files is too small. Usually this limit is per process though and as long as one process does not open many files, the whole simulation can still open very many.

* CarpetIOHDF5: be more carefull closing all open hdf5 files