### PR TITLE
CarpetInterp: make atomic capture operation strictly a supported one

### DIFF
--- a/CarpetInterp/src/interp.cc
+++ b/CarpetInterp/src/interp.cc
@@ -378,8 +378,9 @@ extern "C" CCTK_INT Carpet_DriverInterpolate(
       int const idx = it->second;
       assert(idx < (int)totalhomecnts.size());
       int mytmpcnt;
+      int &tmpcnt = tmpcnts.AT(idx);
 #pragma omp atomic capture
-      mytmpcnt = tmpcnts.AT(idx)++;
+      mytmpcnt = tmpcnt++;
       indices.AT(n) = totalhomecnts.AT(idx) + mytmpcnt;
     }
     assert(tmpcnts == allhomecnts);


### PR DESCRIPTION
nvhpc does not like the omp capture otherwise and reports

```
NVC++-S-0155-Invalid atomic capture statement(s).  (/u/rhaas/Cactus/configs/cpu/build/CarpetInterp/interp.cc: 846)
NVC++/arm Linux 24.3-0: compilation completed with severe errors
```